### PR TITLE
WIP/RFC: crypto: demo for public-key cryptography using libsodium/NaCL

### DIFF
--- a/crypto/c++/.gitignore
+++ b/crypto/c++/.gitignore
@@ -1,0 +1,2 @@
+/build/
+/compile_commands.json

--- a/crypto/c++/LoadFile.hxx
+++ b/crypto/c++/LoadFile.hxx
@@ -1,0 +1,50 @@
+#include <vector>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+static std::vector<unsigned char>
+LoadFile(const char *path)
+{
+	int fd = open(path, O_RDONLY);
+	if (fd < 0) {
+		fprintf(stderr, "Failed to open %s: %s\n",
+			path, strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+
+	struct stat st;
+	if (fstat(fd, &st) < 0) {
+		fprintf(stderr, "Failed to access %s: %s\n",
+			path, strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+
+	if (!S_ISREG(st.st_mode)) {
+		fprintf(stderr, "Not a regular file: %s\n", path);
+		exit(EXIT_FAILURE);
+	}
+
+	if (st.st_size > 1024 * 1024) {
+		fprintf(stderr, "File too large: %s\n", path);
+		exit(EXIT_FAILURE);
+	}
+
+	std::vector<unsigned char> result;
+	result.resize(st.st_size);
+
+	ssize_t nbytes = read(fd, &result.front(), st.st_size);
+	if (nbytes < 0) {
+		fprintf(stderr, "Failed to read %s: %s\n",
+			path, strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+
+	close(fd);
+	return result;
+}

--- a/crypto/c++/SaveFile.hxx
+++ b/crypto/c++/SaveFile.hxx
@@ -1,0 +1,27 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+static void
+SaveFile(const char *path, const void *data, size_t size)
+{
+	int fd = open(path, O_CREAT|O_TRUNC|O_WRONLY, 0666);
+	if (fd < 0) {
+		fprintf(stderr, "Failed to create %s: %s\n",
+			path, strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+
+	ssize_t nbytes = write(fd, data, size);
+	if (nbytes < 0) {
+		fprintf(stderr, "Failed to write %s: %s\n",
+			path, strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+
+	close(fd);
+}

--- a/crypto/c++/genkey.cxx
+++ b/crypto/c++/genkey.cxx
@@ -1,0 +1,26 @@
+#include "SaveFile.hxx"
+
+#include <sodium/crypto_box.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+int
+main(int argc, char **argv)
+{
+	if (argc != 3) {
+		fprintf(stderr,
+			"Usage: %s PUBLICKEYFILE SECRETKEYFILE\n",
+			argv[0]);
+		return EXIT_FAILURE;
+	}
+
+	unsigned char pk[crypto_box_PUBLICKEYBYTES];
+	unsigned char sk[crypto_box_SECRETKEYBYTES];
+	crypto_box_keypair(pk, sk);
+
+	SaveFile(argv[1], pk, sizeof(pk));
+	SaveFile(argv[2], sk, sizeof(sk));
+
+	return EXIT_SUCCESS;
+}

--- a/crypto/c++/meson.build
+++ b/crypto/c++/meson.build
@@ -1,0 +1,51 @@
+project('recvr-app', 'cpp', version: '0.1',
+  default_options: [
+    'cpp_std=c++17'
+  ],
+)
+
+compiler = meson.get_compiler('cpp')
+
+common_flags = [
+  '-D_GNU_SOURCE',
+  '-Wall',
+  '-Wextra',
+  '-Wwrite-strings', '-Wcast-qual', '-Wcast-align', '-Wfloat-equal',
+  '-Wshadow', '-Wpointer-arith', '-Wsign-compare',
+  '-Wmissing-declarations', '-Wmissing-noreturn', '-Wmissing-format-attribute',
+  '-Wredundant-decls', '-Wno-long-long', '-Wundef',
+  '-Wunused',
+  '-Wundef',
+]
+
+add_global_arguments(
+  common_flags,
+  '-Wno-missing-field-initializers',
+  '-Wno-non-virtual-dtor',
+  language: 'cpp')
+
+libsodium = dependency('libsodium')
+
+executable(
+  'genkey',
+  'genkey.cxx',
+  dependencies: [
+    libsodium,
+  ],
+)
+
+executable(
+  'seal',
+  'seal.cxx',
+  dependencies: [
+    libsodium,
+  ],
+)
+
+executable(
+  'open',
+  'open.cxx',
+  dependencies: [
+    libsodium,
+  ],
+)

--- a/crypto/c++/open.cxx
+++ b/crypto/c++/open.cxx
@@ -1,0 +1,55 @@
+#include "LoadFile.hxx"
+#include "SaveFile.hxx"
+
+#include <sodium/crypto_box.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+int
+main(int argc, char **argv)
+{
+	if (argc != 5) {
+		fprintf(stderr,
+			"Usage: %s SECRETKEYFILE PUBLICKEYFILE INPUTFILE OUTPUTFILE\n",
+			argv[0]);
+		return EXIT_FAILURE;
+	}
+
+	const auto secret_key = LoadFile(argv[1]);
+	if (secret_key.size() != crypto_box_SECRETKEYBYTES) {
+		fprintf(stderr, "Not a secret key: %s\n", argv[1]);
+		exit(EXIT_FAILURE);
+	}
+
+	const auto public_key = LoadFile(argv[2]);
+	if (public_key.size() != crypto_box_PUBLICKEYBYTES) {
+		fprintf(stderr, "Not a public key: %s\n", argv[2]);
+		exit(EXIT_FAILURE);
+	}
+
+	const auto input = LoadFile(argv[3]);
+	if (input.size() < crypto_box_SEALBYTES) {
+		fprintf(stderr, "Not an encrypted file: %s\n", argv[3]);
+		exit(EXIT_FAILURE);
+	}
+
+	std::vector<unsigned char> output;
+	output.resize(input.size() - crypto_box_SEALBYTES);
+
+	if (crypto_box_seal_open(&output.front(), &input.front(), input.size(),
+				 &public_key.front(),
+				 &secret_key.front()) != 0) {
+		fprintf(stderr, "Failed to decrypt file\n");
+		exit(EXIT_FAILURE);
+	}
+
+	SaveFile(argv[4], &output.front(), output.size());
+
+	return EXIT_SUCCESS;
+}

--- a/crypto/c++/seal.cxx
+++ b/crypto/c++/seal.cxx
@@ -1,0 +1,40 @@
+#include "LoadFile.hxx"
+#include "SaveFile.hxx"
+
+#include <sodium/crypto_box.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+int
+main(int argc, char **argv)
+{
+	if (argc != 4) {
+		fprintf(stderr,
+			"Usage: %s PUBLICKEYFILE INPUTFILE OUTPUTFILE\n",
+			argv[0]);
+		return EXIT_FAILURE;
+	}
+
+	const auto public_key = LoadFile(argv[1]);
+	if (public_key.size() != crypto_box_PUBLICKEYBYTES) {
+		fprintf(stderr, "Not a public key: %s\n", argv[1]);
+		exit(EXIT_FAILURE);
+	}
+
+	const auto input = LoadFile(argv[2]);
+
+	std::vector<unsigned char> output;
+	output.resize(crypto_box_SEALBYTES + input.size());
+
+	crypto_box_seal(&output.front(), &input.front(), input.size(),
+			&public_key.front());
+	SaveFile(argv[3], &output.front(), output.size());
+
+	return EXIT_SUCCESS;
+}

--- a/crypto/node/open.js
+++ b/crypto/node/open.js
@@ -1,0 +1,17 @@
+#!/usr/bin/node
+
+var fs = require('fs');
+
+if (process.argv.length < 3) {
+    console.log('Usage: node ' + process.argv[1] + ' SECRETKEYFILE PUBLICKEYFILE INPUTFILE OUTPUTFILE');
+    process.exit(1);
+}
+
+var secretKey = fs.readFileSync(process.argv[2]);
+var publicKey = fs.readFileSync(process.argv[3]);
+var input = fs.readFileSync(process.argv[4]);
+
+var tweetnacl = require('tweetnacl');
+tweetnacl.sealedbox = require('tweetnacl-sealedbox-js');
+
+fs.writeFileSync(process.argv[5], tweetnacl.sealedbox.open(input, publicKey, secretKey));

--- a/crypto/node/seal.js
+++ b/crypto/node/seal.js
@@ -1,0 +1,16 @@
+#!/usr/bin/node
+
+var fs = require('fs');
+
+if (process.argv.length < 3) {
+    console.log('Usage: node ' + process.argv[1] + ' PUBLICKEYFILE INPUTFILE OUTPUTFILE');
+    process.exit(1);
+}
+
+var publicKey = fs.readFileSync(process.argv[2]);
+var input = fs.readFileSync(process.argv[3]);
+
+var tweetnacl = require('tweetnacl');
+tweetnacl.sealedbox = require('tweetnacl-sealedbox-js');
+
+fs.writeFileSync(process.argv[4], tweetnacl.sealedbox.seal(input, publicKey));

--- a/crypto/web/demo.js
+++ b/crypto/web/demo.js
@@ -1,0 +1,23 @@
+function genKey() {
+    var keyPair = nacl.box.keyPair();
+    document.getElementById("secretKey").value = btoa(String.fromCharCode.apply(null, keyPair.secretKey));
+    document.getElementById("publicKey").value = btoa(String.fromCharCode.apply(null, keyPair.publicKey));
+}
+
+function encrypt() {
+    var input = new TextEncoder().encode(document.getElementById("plainText").value)
+    var publicKey = Uint8Array.from(atob(document.getElementById("publicKey").value), c => c.charCodeAt(0))
+    var sealed = sealedBox.seal(input, publicKey);
+    document.getElementById("encrypted").value = btoa(String.fromCharCode.apply(null, sealed));
+}
+
+function decrypt() {
+    var input = Uint8Array.from(atob(document.getElementById("encrypted").value), c => c.charCodeAt(0))
+    var secretKey = Uint8Array.from(atob(document.getElementById("secretKey").value), c => c.charCodeAt(0))
+    var publicKey = Uint8Array.from(atob(document.getElementById("publicKey").value), c => c.charCodeAt(0))
+    var decrypted = sealedBox.open(input, publicKey, secretKey);
+    if (decrypted)
+        document.getElementById("plainText").value = new TextDecoder().decode(decrypted)
+    else
+        document.getElementById("plainText").value = "Error";
+}

--- a/crypto/web/index.html
+++ b/crypto/web/index.html
@@ -1,0 +1,35 @@
+<html>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
+  </head>
+  <body>
+    <script src="https://tweetnacl.js.org/nacl.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/tweetnacl-sealedbox-js@1.2.0/sealedbox.web.js"></script>
+    <script src="demo.js"></script>
+
+    <table>
+      <tbody>
+        <tr>
+          <td>Secret key (b64):</td>
+          <td><input id="secretKey" size="50"></input></td>
+        </tr>
+        <tr>
+          <td>Public key (b64):</td>
+          <td><input id="publicKey" size="50"></input></td>
+        </tr>
+        <tr>
+          <td>Plain text:</td>
+          <td><input id="plainText" size="50"></input></td>
+        </tr>
+        <tr>
+          <td>Encrypted (b64):</td>
+          <td><input id="encrypted" size="80"></input></td>
+        </tr>
+      </tbody>
+    </table>
+
+    <button onclick="genKey()">Generate keypair</button>
+    <button onclick="encrypt()">Encrypt</button>
+    <button onclick="decrypt()">Decrypt</button>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -5364,6 +5364,11 @@
         "file-uri-to-path": "1.0.0"
       }
     },
+    "blakejs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
+      "integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -18070,6 +18075,22 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
+    },
+    "tweetnacl-sealedbox-js": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tweetnacl-sealedbox-js/-/tweetnacl-sealedbox-js-1.2.0.tgz",
+      "integrity": "sha512-QoCr8K2hwri+ky7SUa22oSre8g88XaWi0hwwWd16pJMuDyn5gL/UyE0PyR2EOFEMJ70T2trJ9+Sv+Qa18olEmQ==",
+      "requires": {
+        "blakejs": "^1.1.0",
+        "tweetnacl": "^1.0.1"
+      },
+      "dependencies": {
+        "tweetnacl": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+          "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+        }
+      }
     },
     "type": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react-dom": "16.13.1",
     "react-query": "^1.3.3",
     "styled-system": "^5.1.5",
+    "tweetnacl-sealedbox-js": "^1.2.0",
     "typeface-nunito": "^1.1.3",
     "uuid": "^8.0.0"
   },


### PR DESCRIPTION
This is a technical demonstration for the use of libsodium for
public-key cryptography.  libsodium's "crypto box" module has a "seal"
feature for anonymous (i.e. unauthenticated) public-key encryption.
It uses Curve25519, XSalsa20 and Poly1305.

There are 3 subdirectories:

- c++: several tiny command-line utilities for libsodium's
  cryptobox/seal feature in C++; I wrote these only to verify that the
  JavaScript libraries are really compatible with `libsodium`

- node: the same command-line utilities written in JavaScript, to be
  invoked with NodeJS

- web: a small website demonstrating the same features in a browser

How to implement:

- integrate the JavaScript libraries
  https://github.com/dchest/tweetnacl-js and
  https://github.com/whs/tweetnacl-sealed-box

- the recipient (the one who shall be able to decrypt the messages)
  generates a key pair with `nacl.box.keyPair()` and saves both keys

- the recipient publishes his public key (e.g. encoded as a URL
  parameter, printed as a QR code on a piece of paper)

- the sender scans the QR code and extracts the public key

- the sender uses this public key to encrypt messages with
  `sealedBox.seal()`

- the recipient decrypts those messages with `sealedBox.open()` and
  his key pair