### PR TITLE
Change last visible checkins for owner from 6 to 24 hours

### DIFF
--- a/lib/hooks/useLastTickets.ts
+++ b/lib/hooks/useLastTickets.ts
@@ -8,7 +8,7 @@ async function fetchLastTickets(
   companyId: string
 ): Promise<CompanyTicketRes[]> {
   const to = new Date()
-  const from = new Date(subHours(to, 6))
+  const from = new Date(subHours(to, 24))
   return await getTickets({ companyId, from, to })
 }
 

--- a/pages/business/company/[companyId]/area/[areaId].tsx
+++ b/pages/business/company/[companyId]/area/[areaId].tsx
@@ -24,7 +24,7 @@ const AreasIndexPage: React.FC<WithOwnerProps> = () => {
         Checkins
       </BackLink>
       <Text variant="shy">
-        Checkins der letzten 6 Stunden. Aktualisiert sich automatisch.
+        Checkins der letzten 24 Stunden. Aktualisiert sich automatisch.
       </Text>
       <Box height={2} />
       <DataList>

--- a/pages/business/company/[companyId]/checkins.tsx
+++ b/pages/business/company/[companyId]/checkins.tsx
@@ -24,7 +24,7 @@ const CheckinsPage: React.FC<WithOwnerProps> = () => {
         {company?.name}
       </BackLink>
       <Text variant="shy">
-        Checkins der letzten 6 Stunden. Aktualisiert sich automatisch.
+        Checkins der letzten 24 Stunden. Aktualisiert sich automatisch.
       </Text>
       <Box height={2} />
       <ActionList grid>


### PR DESCRIPTION
Shows checkins from last 24 hours in the owner's backoffice. This was a feedback from some owners who want to check how the checkins were used at the end of the day.