### PR TITLE
Configure project to support recover care build variant

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,4 @@
+# Set to `care` to use recover care variant
+BUILD_VARIANT=rcvr
+
 NEXT_PUBLIC_API_BASE=https://api.rcvr.app/

--- a/.env
+++ b/.env
@@ -1,4 +1,5 @@
 # Set to `care` to use recover care variant
 BUILD_VARIANT=rcvr
+NEXT_PUBLIC_BUILD_VARIANT=$BUILD_VARIANT
 
 NEXT_PUBLIC_API_BASE=https://api.rcvr.app/

--- a/README.md
+++ b/README.md
@@ -81,6 +81,16 @@ npm run dev -- -p 3333
 
 If you want to change environment variables locally, for example the API URL, you can duplicate `.env` to `.env.local` and change the variables in your local copy. Read more about environment variables [here](https://nextjs.org/docs/basic-features/environment-variables).
 
+### Build variants
+
+_[recover care](https://care.rcvr.app/)_ has slight differences in theming and behavior. To switch to recover care, set the environment variable `BUILD_VARIANT=care`.
+
+```
+BUILD_VARIANT=care npm run dev
+```
+
+**Branches** with the prefix `care/` will automatically have deployment previews using the _recover care_ build variant.
+
 ## License
 
 AGPL, © 2020 Railslove GmbH

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "node ./scripts/build.js",
+    "next-build": "next build",
     "start": "next start",
     "lint": "eslint . --ext .ts,.tsx,.js",
     "typecheck": "tsc --noemit",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -5,8 +5,13 @@ const isCareBranch =
   process.env.VERCEL_GITHUB_COMMIT_REF.startsWith('care/')
 const isCareDomain = process.env.VERCEL_URL === 'care.rcvr.app'
 
+console.log(process.env.VERCEL_GITHUB_COMMIT_REF)
+console.log({ isCareBranch, isCareDomain })
+
 if (isCareBranch || isCareDomain) {
   process.env.BUILD_VARIANT = 'care'
 }
+
+console.log('variant: ', process.env.BUILD_VARIANT)
 
 execSync('npm run next-build', { stdio: 'inherit' })

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,17 +1,15 @@
 const execSync = require('child_process').execSync
 
+const isCareDomain = process.env.VERCEL_URL === 'care.rcvr.app'
 const isCareBranch =
   process.env.VERCEL_GITHUB_COMMIT_REF &&
   process.env.VERCEL_GITHUB_COMMIT_REF.startsWith('care/')
-const isCareDomain = process.env.VERCEL_URL === 'care.rcvr.app'
-
-console.log(process.env.VERCEL_GITHUB_COMMIT_REF)
-console.log({ isCareBranch, isCareDomain })
 
 if (isCareBranch || isCareDomain) {
+  console.log('Using BUILD_VARIANT: care')
   process.env.BUILD_VARIANT = 'care'
+} else {
+  console.log('No automatic BUILD_VARIANT detected. Using default from .env')
 }
-
-console.log('variant: ', process.env.BUILD_VARIANT)
 
 execSync('npm run next-build', { stdio: 'inherit' })

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,12 @@
+const execSync = require('child_process').execSync
+
+const isCareBranch =
+  process.env.VERCEL_GITHUB_COMMIT_REF &&
+  process.env.VERCEL_GITHUB_COMMIT_REF.startsWith('care/')
+const isCareDomain = process.env.VERCEL_URL === 'care.rcvr.app'
+
+if (isCareBranch || isCareDomain) {
+  process.env.BUILD_VARIANT = 'care'
+}
+
+execSync('npm run next-build', { stdio: 'inherit' })

--- a/ui/theme.ts
+++ b/ui/theme.ts
@@ -42,7 +42,7 @@ const theme = {
       900: '#090e10',
     },
     black: '#000000',
-    green: '#28EE5F',
+    green: process.env.BUILD_VARIANT === 'care' ? '#4DB6AC' : '#28EE5F',
     pink: '#EA28EE',
     yellow: {
       50: '#fff8dc',


### PR DESCRIPTION
_recover care_ is a version of recover for hospitals, nursing homes, etc.

This PR introduces the possibility of having different build variants for customization purposes. The `care` build variant will automatically be applied to the care.rcvr.app subdomain and any branches starting with `care/`.