### PR TITLE
Show checkout time from server

### DIFF
--- a/lib/actions/checkout.ts
+++ b/lib/actions/checkout.ts
@@ -4,9 +4,12 @@ import * as api from '../api'
 
 export async function checkout(checkin: db.Checkin): Promise<db.Checkin> {
   const leftAt = new Date()
-  await api.patchTicket({ id: checkin.id, leftAt })
+  const ticket = await api.patchTicket({ id: checkin.id, leftAt })
 
-  const checkout = await db.updateCheckin({ id: checkin.id, leftAt })
+  const checkout = await db.updateCheckin({
+    id: checkin.id,
+    leftAt: ticket.leftAt,
+  })
   queryCache.refetchQueries('checkins', { force: true })
   return checkout
 }


### PR DESCRIPTION
When checking out after the server has performed an auto-checkout of a ticket, we now display the server's checkout time instead of the clients time.