### PR TITLE
Check if key is decodable on checkin page load

### DIFF
--- a/lib/crypto.ts
+++ b/lib/crypto.ts
@@ -5,7 +5,7 @@ import { parse } from 'papaparse'
 import { AppError } from './error'
 import { Guest } from './db'
 
-function binKey(key: string): Uint8Array {
+export function binKey(key: string): Uint8Array {
   try {
     return Uint8Array.from(atob(key), (c) => c.charCodeAt(0))
   } catch (error) {

--- a/pages/checkin.tsx
+++ b/pages/checkin.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router'
 import { v4 as uuidv4 } from 'uuid'
 import { useMutation } from 'react-query'
 
+import { binKey } from '~lib/crypto'
 import { checkin, checkout } from '~lib/actions'
 import { useCurrentGuest, useArea } from '~lib/hooks'
 import { Guest, updateGuest, addGuest, getLastCheckin } from '~lib/db'
@@ -87,6 +88,10 @@ export default function CheckinPage() {
     if (hasStarted.current) return
     hasStarted.current = true
 
+    // Checks if the publicKey is decodable. Throws an error and shows the
+    // corresponding error page if not.
+    binKey(publicKey)
+
     const guest = guestInfo.data
 
     // Check if a guest was already created, then do the checkin cha cha cha.
@@ -106,7 +111,7 @@ export default function CheckinPage() {
       setShowOnboarding(true)
       setShowLoading(false)
     }
-  }, [isReady, checkinAndRedirect, areaInfo, guestInfo])
+  }, [isReady, checkinAndRedirect, areaInfo, guestInfo, publicKey])
 
   return (
     <MobileApp logoVariant="big">


### PR DESCRIPTION
Some 3rd party QR-Code Scanners decode the URL before redirecting, which breaks the publicKey. We already catch this error and show a corresponding error page, but only after the guest entered their details.

Now the key will be decoded on page load, which throws an error if the key is not correctly encoded, before the guest entered their details.