### PR TITLE
Bring in the menu also on mobile

### DIFF
--- a/ui/blocks/LastCheckins.tsx
+++ b/ui/blocks/LastCheckins.tsx
@@ -6,7 +6,6 @@ import { v4 as uuidv4 } from 'uuid'
 
 import { Guest } from '~lib/db/guest'
 import { Onboarding } from '~ui/blocks/Onboarding'
-import { AreaRes } from '~lib/api'
 import { checkin as checkinAction } from '~lib/actions'
 import { Checkin } from '~lib/db'
 import { Box, Text, Button } from '~ui/core'

--- a/ui/layouts/OwnerApp.tsx
+++ b/ui/layouts/OwnerApp.tsx
@@ -37,6 +37,14 @@ export const OwnerApp: React.FC<Props> = ({ children, title }) => {
           <Logo />
         </LogoBox>
         <FetchingIndicator />
+        <MobileMenu>
+          <li>
+            <NavLink href="/business/dashboard">Betriebe</NavLink>
+          </li>
+          <li>
+            <NavLink href="/business/profile">Profil</NavLink>
+          </li>
+        </MobileMenu>
       </Top>
       <Wrapper>
         <Aside>
@@ -222,6 +230,15 @@ const Aside = styled('aside')(
 
     'ul ul li': {
       mb: 2,
+    },
+  })
+)
+
+const MobileMenu = styled('ul')(
+  css({
+    display: ['flex', 'none', 'none'],
+    '> li': {
+      mr: 2,
     },
   })
 )


### PR DESCRIPTION
After Timos remarks and after talking to Max I just added a mobile menu in the header as a quick fix for the problems our users have. Adding it to the content would add some complexity because all content is nested inside the `OwnerApp` module, so having it above the "Meine Betriebe" headline seamed some effort...

<img width="305" alt="Bildschirmfoto 2020-10-20 um 16 07 18" src="https://user-images.githubusercontent.com/74421/96598034-bf8ae780-12ee-11eb-88cc-e7b9ba9d71ae.png">
