### PR TITLE
Feature/Takes over the address when checking in with several people

### DIFF
--- a/ui/blocks/LastCheckins.tsx
+++ b/ui/blocks/LastCheckins.tsx
@@ -162,6 +162,12 @@ export const LastCheckins: React.FC<Props> = ({ checkins, onCheckout }) => {
                 <Text variant="h3">Wen willst du mit dir einchecken?</Text>
                 <Box height={2} />
                 <Onboarding
+                  prefilledGuest={{
+                    address: checkin.guest?.address,
+                    postalCode: checkin.guest?.postalCode,
+                    city: checkin.guest?.city,
+                    phone: checkin.guest?.phone,
+                  }}
                   hideRememberMe={true}
                   onSubmit={proxyCheckin}
                   onAbort={() => setShowProxyCheckin(false)}


### PR DESCRIPTION
Closes https://github.com/railslove/recover-backlog/issues/34

I also added the phone number to be copied over. I couldn't think of a scenario where you want to copy the address but then a different phone number. 

Fixes also a tiny html warning that I noticed - thought I put it in here because it's not worth its own PR.
<img width="938" alt="Screen Shot 2020-12-09 at 10 33 43 AM" src="https://user-images.githubusercontent.com/15280263/101624469-40767d80-3a1a-11eb-9e9b-62ac1bcdfbbd.png">
