### PR TITLE
44 prefill qr quest info

### DIFF
--- a/pages/qr.tsx
+++ b/pages/qr.tsx
@@ -5,9 +5,29 @@ import { Text, Card, Box } from '~ui/core'
 import { isFormal } from '~lib/config'
 import { ArrowsLeft, ArrowsRight } from '~ui/anicons'
 import { MobileApp } from '~ui/layouts/MobileApp'
+import { useRouter } from 'next/router'
 
 export default function QRCodePage() {
   const videoEl = React.useRef<HTMLVideoElement>()
+
+  const router = useRouter()
+
+  const paramsRef = React.useRef<object>({})
+
+  paramsRef.current = {
+    name: router.query.name?.toString(),
+    phone: router.query.phone?.toString(),
+    address: router.query.address?.toString(),
+  }
+
+  function appendGuestInfo(url: string): any {
+    Object.entries(paramsRef.current).forEach((entry) => {
+      if (entry[1]) {
+        url = url.concat(`&${entry[0]}=${entry[1]}`)
+      }
+    })
+    return url
+  }
 
   React.useEffect(() => {
     let qrCodeReader: any
@@ -22,7 +42,7 @@ export default function QRCodePage() {
           undefined,
           videoEl.current
         )
-        window.location.href = result.getText()
+        window.location.href = appendGuestInfo(result.getText())
       } catch (error) {
         console.error('Failed mountAndWaitForScan:', error)
       }

--- a/pages/qr.tsx
+++ b/pages/qr.tsx
@@ -1,31 +1,18 @@
-import * as React from 'react'
 import Head from 'next/head'
-
-import { Text, Card, Box } from '~ui/core'
+import * as React from 'react'
 import { isFormal } from '~lib/config'
 import { ArrowsLeft, ArrowsRight } from '~ui/anicons'
+import { Box, Card, Text } from '~ui/core'
 import { MobileApp } from '~ui/layouts/MobileApp'
-import { useRouter } from 'next/router'
 
 export default function QRCodePage() {
   const videoEl = React.useRef<HTMLVideoElement>()
 
-  const router = useRouter()
-
-  const paramsRef = React.useRef<object>({})
-
-  paramsRef.current = {
-    name: router.query.name?.toString(),
-    phone: router.query.phone?.toString(),
-    address: router.query.address?.toString(),
-  }
-
-  function appendGuestInfo(url: string): any {
-    Object.entries(paramsRef.current).forEach((entry) => {
-      if (entry[1]) {
-        url = url.concat(`&${entry[0]}=${entry[1]}`)
-      }
-    })
+  function appendUrlParams(url: string): any {
+    const params = new URLSearchParams(new URL(window.location.href).search)
+    for (const [key, value] of params.entries()) {
+      url = url.concat(`&${key}=${value}`)
+    }
     return url
   }
 
@@ -42,7 +29,7 @@ export default function QRCodePage() {
           undefined,
           videoEl.current
         )
-        window.location.href = appendGuestInfo(result.getText())
+        window.location.href = appendUrlParams(result.getText())
       } catch (error) {
         console.error('Failed mountAndWaitForScan:', error)
       }

--- a/pages/qr.tsx
+++ b/pages/qr.tsx
@@ -10,10 +10,12 @@ export default function QRCodePage() {
 
   function appendUrlParams(url: string): any {
     const params = new URLSearchParams(new URL(window.location.href).search)
+    const qrUrl = new URL(url)
+
     for (const [key, value] of params.entries()) {
-      url = url.concat(`&${key}=${value}`)
+      qrUrl.searchParams.append(key, value)
     }
-    return url
+    return qrUrl.toString()
   }
 
   React.useEffect(() => {


### PR DESCRIPTION
We hit this issue with next router vercel/next.js#10521. This caused the query params to
be sometimes empty.
We introduced a React. ref to create a mutable state for the query params in order for them to be accessible from within the mountAndWaitForScan callback.

close railslove/recover-backlog#44