### PR TITLE
58 add custom data protection field

### DIFF
--- a/lib/api/areas.ts
+++ b/lib/api/areas.ts
@@ -17,6 +17,7 @@ export interface AreaRes {
   companyId: string
   companyName: string
   menuLink?: string
+  privacyPolicyLink?: string
   menuAlias?: string
   ownerIsBlocked: boolean
   frontendUrl: string

--- a/lib/api/companies.ts
+++ b/lib/api/companies.ts
@@ -4,6 +4,7 @@ import { api, AreaRes } from './'
 export interface CompanyReq extends FormData {
   'company[name]'?: FormDataEntryValue
   'company[menu_link]'?: FormDataEntryValue
+  'company[privacy_policy_link]'?: FormDataEntryValue
   'company[menu_pdf]'?: File
 }
 
@@ -11,6 +12,7 @@ export interface CompanyRes {
   id: string
   name: string
   menuLink?: string
+  privacyPolicyLink?: string
   menuPdfLink?: string
   areas: AreaRes[]
 }

--- a/pages/business/dashboard.tsx
+++ b/pages/business/dashboard.tsx
@@ -40,6 +40,7 @@ const DashboardPage: React.FC<WithOwnerProps> = ({ owner }) => {
                 type: 'edit',
                 name: company.name,
                 menuLink: company.menuLink,
+                privacyPolicyLink: company.privacyPolicyLink,
                 menuPdfLink: menuPdfFileName(company),
                 menuAlias: owner.menuAlias,
                 companyId: company.id,

--- a/pages/checkin.tsx
+++ b/pages/checkin.tsx
@@ -224,8 +224,23 @@ export default function CheckinPage() {
                 onSubmit={handleSubmitOnboarding}
                 prefilledGuest={prefilledGuest}
               />
+              {areaInfo.data.privacyPolicyLink && (
+                <>
+                  <Box height={4} />
+                  <a
+                    target="_blank"
+                    rel="noreferrer noopener"
+                    href={areaInfo.data.privacyPolicyLink}
+                  >
+                    <Text variant="link">
+                      Datenschutzerklärung von {areaInfo.data.companyName}
+                    </Text>
+                  </a>
+                </>
+              )}
             </Card>
           )}
+
           {showConfirmation && <Confirmation onSubmit={tryAutoCheckin} />}
           <Row justifyContent="center" my={6}>
             <a

--- a/ui/modals/BusinessDataModal.tsx
+++ b/ui/modals/BusinessDataModal.tsx
@@ -15,12 +15,14 @@ interface Props {
   menuPdfLink?: string
   menuAlias?: string
   companyId?: string
+  privacyPolicyLink?: string
 }
 type MProps = ModalBaseProps & Props
 
 const BusinessSchema = Yup.object().shape({
   name: Yup.string().required('Du musst einen Namen angeben.'),
   menuLink: Yup.string(),
+  privacyPolicyLink: Yup.string(),
   menuPdf: Yup.mixed().test(
     'isPDF',
     'Es können nur pdf-Dateien hochgeladen werden.',
@@ -45,22 +47,30 @@ export const BusinessDataModal: React.FC<MProps> = ({
   menuPdfLink,
   menuAlias,
   companyId,
+  privacyPolicyLink,
   ...baseProps
 }) => {
   const title = { new: 'Neuer Betrieb', edit: 'Betrieb ändern' }[type]
   const button = { new: 'Hinzufügen', edit: 'Speichern' }[type]
   const [loading, setLoading] = React.useState(false)
 
+  const safeLink = (link: string) => {
+    let safeLink = link
+    if (safeLink && !safeLink.startsWith('http')) {
+      safeLink = 'https://' + safeLink
+    }
+    return safeLink
+  }
+
   const handleSubmit = React.useCallback(
-    async ({ name, menuLink, menuPdf }, bag) => {
-      let safeMenuLink = menuLink
-      if (menuLink && !menuLink.startsWith('http')) {
-        safeMenuLink = 'https://' + menuLink
-      }
+    async ({ name, menuLink, menuPdf, privacyPolicyLink }, bag) => {
+      const safeMenuLink = safeLink(menuLink)
+      const safePrivacyPolicyLink = safeLink(privacyPolicyLink)
 
       const formData = new FormData()
       formData.append('company[name]', name)
       formData.append('company[menu_link]', safeMenuLink)
+      formData.append('company[privacy_policy_link]', safePrivacyPolicyLink)
       if (menuPdf !== menuPdfLink) {
         if (menuPdf === undefined) {
           formData.append('company[remove_menu_pdf]', '1')
@@ -98,6 +108,7 @@ export const BusinessDataModal: React.FC<MProps> = ({
         initialValues={{
           name: name || '',
           menuLink: menuLink || '',
+          privacyPolicyLink: privacyPolicyLink || '',
           menuPdf: menuPdfLink,
         }}
         validationSchema={BusinessSchema}
@@ -105,6 +116,11 @@ export const BusinessDataModal: React.FC<MProps> = ({
       >
         <Form>
           <Input name="name" label="Name des Betriebs" autoFocus />
+          <Box height={4} />
+          <Input
+            name="privacyPolicyLink"
+            label={'Datenschutzerklärung als Link'}
+          />
           <Box height={4} />
           {
             <>


### PR DESCRIPTION
closes closes railslove/recover-backlog#58

- Adds possibility to add custom privacy url link in owners dashboard

![Screenshot 2020-12-28 at 20 12 01](https://user-images.githubusercontent.com/1360387/103240696-f4e42f00-4948-11eb-9773-cae007a917ed.png)

- Adds link to privacy policy beneath checkin button it was configured by owner

![Screenshot 2020-12-28 at 20 12 43](https://user-images.githubusercontent.com/1360387/103240784-2fe66280-4949-11eb-9b0a-aa78871577ba.png)

