### PR TITLE
Fix warnings in tests

### DIFF
--- a/lib/testing/fileTransformer.js
+++ b/lib/testing/fileTransformer.js
@@ -1,0 +1,7 @@
+const path = require('path')
+
+module.exports = {
+  process(_src, filename) {
+    return `module.exports = ${JSON.stringify(path.basename(filename))};`
+  },
+}

--- a/lib/testing/svgImportMock.js
+++ b/lib/testing/svgImportMock.js
@@ -1,3 +1,0 @@
-module.exports = function SvgMockComponent() {
-  return 'svg-mock'
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "dexie": "^3.0.1",
         "emotion-theming": "^10.0.27",
         "formik": "^2.1.4",
-        "framer-motion": "^2.0.0-beta.72",
+        "framer-motion": "^2.9.5",
         "iban": "0.0.14",
         "intl-dateformat": "^0.1.4",
         "ky": "^0.19.1",
@@ -2183,7 +2183,6 @@
         "jest-resolve": "^26.0.1",
         "jest-util": "^26.0.1",
         "jest-worker": "^26.0.0",
-        "node-notifier": "^7.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -2737,23 +2736,6 @@
       "version": "9.4.4",
       "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-9.4.4.tgz",
       "integrity": "sha512-9nKENeWRI6kQk44TbeqleIVtNLfcS3klVUepzl/ZCqzR5Bi06uqBCD277hdVvG/wL1pxA+R/pgJQLqnF5E2wPQ=="
-    },
-    "node_modules/@popmotion/easing": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@popmotion/easing/-/easing-1.0.2.tgz",
-      "integrity": "sha512-IkdW0TNmRnWTeWI7aGQIVDbKXPWHVEYdGgd5ZR4SH/Ty/61p63jCjrPxX1XrR7IGkl08bjhJROStD7j+RKgoIw=="
-    },
-    "node_modules/@popmotion/popcorn": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@popmotion/popcorn/-/popcorn-0.4.4.tgz",
-      "integrity": "sha512-jYO/8319fKoNLMlY4ZJPiPu8Ea8occYwRZhxpaNn/kZsK4QG2E7XFlXZMJBsTWDw7I1i0uaqyC4zn1nwEezLzg==",
-      "dependencies": {
-        "@popmotion/easing": "^1.0.1",
-        "framesync": "^4.0.1",
-        "hey-listen": "^1.0.8",
-        "style-value-types": "^3.1.7",
-        "tslib": "^1.10.0"
-      }
     },
     "node_modules/@scarf/scarf": {
       "version": "1.0.5",
@@ -4170,7 +4152,6 @@
       "resolved": "https://registry.npmjs.org/@zxing/library/-/library-0.17.0.tgz",
       "integrity": "sha512-P7T2k0y2mhtLyXDoHI4IzwD2KDId/CCi9PMy56Xvr2MCj+gO8RfAy0loOX9TF9eWmhi5LzbSxcz4Xkvi1Bs0/Q==",
       "dependencies": {
-        "@sinonjs/text-encoding": "0.7.1",
         "ts-custom-error": "^3.0.0"
       },
       "engines": {
@@ -5655,7 +5636,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -8344,7 +8324,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.2",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -8446,28 +8425,30 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "2.0.0-beta.72",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-2.0.0-beta.72.tgz",
-      "integrity": "sha512-tLrDSh3caBf1BApLUDj0nrKFZr15ssQPIy8pFI2g1aPqcnMBrbH/jGlc3yodxhFkBIZWWKje1Yu0oVB9W+kXeA==",
+      "version": "2.9.5",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-2.9.5.tgz",
+      "integrity": "sha512-epSX4Co1YbDv0mjfHouuY0q361TpHE7WQzCp/xMTilxy4kXd+Z23uJzPVorfzbm1a/9q1Yu8T5bndaw65NI4Tg==",
       "dependencies": {
-        "@emotion/is-prop-valid": "^0.8.2",
-        "@popmotion/easing": "^1.0.2",
-        "@popmotion/popcorn": "^0.4.2",
-        "framesync": "^4.0.4",
+        "framesync": "^4.1.0",
         "hey-listen": "^1.0.8",
-        "popmotion": "9.0.0-beta-8",
-        "style-value-types": "^3.1.6",
-        "stylefire": "7.0.3",
+        "popmotion": "9.0.0-rc.20",
+        "style-value-types": "^3.1.9",
         "tslib": "^1.10.0"
+      },
+      "optionalDependencies": {
+        "@emotion/is-prop-valid": "^0.8.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/framesync": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/framesync/-/framesync-4.0.4.tgz",
-      "integrity": "sha512-mdP0WvVHe0/qA62KG2LFUAOiWLng5GLpscRlwzBxu2VXOp6B8hNs5C5XlFigsMgrfDrr2YbqTsgdWZTc4RXRMQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/framesync/-/framesync-4.1.0.tgz",
+      "integrity": "sha512-MmgZ4wCoeVxNbx2xp5hN/zPDCbLSKiDt4BbbslK7j/pM2lg5S0vhTNv1v8BCVb99JPIo6hXBFdwzU7Q4qcAaoQ==",
       "dependencies": {
-        "hey-listen": "^1.0.8",
-        "tslib": "^1.10.0"
+        "hey-listen": "^1.0.5"
       }
     },
     "node_modules/from2": {
@@ -10526,7 +10507,6 @@
         "@types/graceful-fs": "^4.1.2",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-serializer": "^26.0.0",
         "jest-util": "^26.0.1",
@@ -14444,15 +14424,13 @@
       }
     },
     "node_modules/popmotion": {
-      "version": "9.0.0-beta-8",
-      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-9.0.0-beta-8.tgz",
-      "integrity": "sha512-6eQzqursPvnP7ePvdfPeY4wFHmS3OLzNP8rJRvmfFfEIfpFqrQgLsM50Gd9AOvGKJtYJOFknNG+dsnzCpgIdAA==",
+      "version": "9.0.0-rc.20",
+      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-9.0.0-rc.20.tgz",
+      "integrity": "sha512-f98sny03WuA+c8ckBjNNXotJD4G2utG/I3Q23NU69OEafrXtxxSukAaJBxzbtxwDvz3vtZK69pu9ojdkMoBNTg==",
       "dependencies": {
-        "@popmotion/easing": "^1.0.1",
-        "@popmotion/popcorn": "^0.4.2",
-        "framesync": "^4.0.4",
+        "framesync": "^4.1.0",
         "hey-listen": "^1.0.8",
-        "style-value-types": "^3.1.6",
+        "style-value-types": "^3.1.9",
         "tslib": "^1.10.0"
       }
     },
@@ -17058,9 +17036,9 @@
       }
     },
     "node_modules/style-value-types": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-3.1.7.tgz",
-      "integrity": "sha512-jPaG5HcAPs3vetSwOJozrBXxuHo9tjZVnbRyBjxqb00c2saIoeuBJc1/2MtvB8eRZy41u/BBDH0CpfzWixftKg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-3.2.0.tgz",
+      "integrity": "sha512-ih0mGsrYYmVvdDi++/66O6BaQPRPRMQHoZevNNdMMcPlP/cH28Rnfsqf1UEba/Bwfuw9T8BmIMwbGdzsPwQKrQ==",
       "dependencies": {
         "hey-listen": "^1.0.8",
         "tslib": "^1.10.0"
@@ -17149,18 +17127,6 @@
         "@styled-system/typography": "^5.1.2",
         "@styled-system/variant": "^5.1.5",
         "object-assign": "^4.1.1"
-      }
-    },
-    "node_modules/stylefire": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/stylefire/-/stylefire-7.0.3.tgz",
-      "integrity": "sha512-Q0l7NSeFz/OkX+o6/7Zg3VZxSAZeQzQpYomWmIpOehFM/rJNMSLVX5fgg6Q48ut2ETNKwdhm97mPNU643EBCoQ==",
-      "dependencies": {
-        "@popmotion/popcorn": "^0.4.4",
-        "framesync": "^4.0.0",
-        "hey-listen": "^1.0.8",
-        "style-value-types": "^3.1.7",
-        "tslib": "^1.10.0"
       }
     },
     "node_modules/stylehacks": {
@@ -18519,10 +18485,8 @@
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.2.tgz",
       "integrity": "sha512-ymVbbQP40MFTp+cNMvpyBpBtygHnPzPkHqoIwRRj/0B8KhqQwV8LaKjtbaxF2lK4vl8zN9wCxS46IFCU5K4W0g==",
       "dependencies": {
-        "chokidar": "^3.4.0",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0",
-        "watchpack-chokidar2": "^2.0.0"
+        "neo-async": "^2.5.0"
       },
       "optionalDependencies": {
         "chokidar": "^3.4.0",
@@ -21332,23 +21296,6 @@
       "version": "9.4.4",
       "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-9.4.4.tgz",
       "integrity": "sha512-9nKENeWRI6kQk44TbeqleIVtNLfcS3klVUepzl/ZCqzR5Bi06uqBCD277hdVvG/wL1pxA+R/pgJQLqnF5E2wPQ=="
-    },
-    "@popmotion/easing": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@popmotion/easing/-/easing-1.0.2.tgz",
-      "integrity": "sha512-IkdW0TNmRnWTeWI7aGQIVDbKXPWHVEYdGgd5ZR4SH/Ty/61p63jCjrPxX1XrR7IGkl08bjhJROStD7j+RKgoIw=="
-    },
-    "@popmotion/popcorn": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@popmotion/popcorn/-/popcorn-0.4.4.tgz",
-      "integrity": "sha512-jYO/8319fKoNLMlY4ZJPiPu8Ea8occYwRZhxpaNn/kZsK4QG2E7XFlXZMJBsTWDw7I1i0uaqyC4zn1nwEezLzg==",
-      "requires": {
-        "@popmotion/easing": "^1.0.1",
-        "framesync": "^4.0.1",
-        "hey-listen": "^1.0.8",
-        "style-value-types": "^3.1.7",
-        "tslib": "^1.10.0"
-      }
     },
     "@scarf/scarf": {
       "version": "1.0.5",
@@ -26229,28 +26176,24 @@
       }
     },
     "framer-motion": {
-      "version": "2.0.0-beta.72",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-2.0.0-beta.72.tgz",
-      "integrity": "sha512-tLrDSh3caBf1BApLUDj0nrKFZr15ssQPIy8pFI2g1aPqcnMBrbH/jGlc3yodxhFkBIZWWKje1Yu0oVB9W+kXeA==",
+      "version": "2.9.5",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-2.9.5.tgz",
+      "integrity": "sha512-epSX4Co1YbDv0mjfHouuY0q361TpHE7WQzCp/xMTilxy4kXd+Z23uJzPVorfzbm1a/9q1Yu8T5bndaw65NI4Tg==",
       "requires": {
         "@emotion/is-prop-valid": "^0.8.2",
-        "@popmotion/easing": "^1.0.2",
-        "@popmotion/popcorn": "^0.4.2",
-        "framesync": "^4.0.4",
+        "framesync": "^4.1.0",
         "hey-listen": "^1.0.8",
-        "popmotion": "9.0.0-beta-8",
-        "style-value-types": "^3.1.6",
-        "stylefire": "7.0.3",
+        "popmotion": "9.0.0-rc.20",
+        "style-value-types": "^3.1.9",
         "tslib": "^1.10.0"
       }
     },
     "framesync": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/framesync/-/framesync-4.0.4.tgz",
-      "integrity": "sha512-mdP0WvVHe0/qA62KG2LFUAOiWLng5GLpscRlwzBxu2VXOp6B8hNs5C5XlFigsMgrfDrr2YbqTsgdWZTc4RXRMQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/framesync/-/framesync-4.1.0.tgz",
+      "integrity": "sha512-MmgZ4wCoeVxNbx2xp5hN/zPDCbLSKiDt4BbbslK7j/pM2lg5S0vhTNv1v8BCVb99JPIo6hXBFdwzU7Q4qcAaoQ==",
       "requires": {
-        "hey-listen": "^1.0.8",
-        "tslib": "^1.10.0"
+        "hey-listen": "^1.0.5"
       }
     },
     "from2": {
@@ -31061,15 +31004,13 @@
       }
     },
     "popmotion": {
-      "version": "9.0.0-beta-8",
-      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-9.0.0-beta-8.tgz",
-      "integrity": "sha512-6eQzqursPvnP7ePvdfPeY4wFHmS3OLzNP8rJRvmfFfEIfpFqrQgLsM50Gd9AOvGKJtYJOFknNG+dsnzCpgIdAA==",
+      "version": "9.0.0-rc.20",
+      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-9.0.0-rc.20.tgz",
+      "integrity": "sha512-f98sny03WuA+c8ckBjNNXotJD4G2utG/I3Q23NU69OEafrXtxxSukAaJBxzbtxwDvz3vtZK69pu9ojdkMoBNTg==",
       "requires": {
-        "@popmotion/easing": "^1.0.1",
-        "@popmotion/popcorn": "^0.4.2",
-        "framesync": "^4.0.4",
+        "framesync": "^4.1.0",
         "hey-listen": "^1.0.8",
-        "style-value-types": "^3.1.6",
+        "style-value-types": "^3.1.9",
         "tslib": "^1.10.0"
       }
     },
@@ -33289,9 +33230,9 @@
       }
     },
     "style-value-types": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-3.1.7.tgz",
-      "integrity": "sha512-jPaG5HcAPs3vetSwOJozrBXxuHo9tjZVnbRyBjxqb00c2saIoeuBJc1/2MtvB8eRZy41u/BBDH0CpfzWixftKg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-3.2.0.tgz",
+      "integrity": "sha512-ih0mGsrYYmVvdDi++/66O6BaQPRPRMQHoZevNNdMMcPlP/cH28Rnfsqf1UEba/Bwfuw9T8BmIMwbGdzsPwQKrQ==",
       "requires": {
         "hey-listen": "^1.0.8",
         "tslib": "^1.10.0"
@@ -33370,18 +33311,6 @@
         "@styled-system/typography": "^5.1.2",
         "@styled-system/variant": "^5.1.5",
         "object-assign": "^4.1.1"
-      }
-    },
-    "stylefire": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/stylefire/-/stylefire-7.0.3.tgz",
-      "integrity": "sha512-Q0l7NSeFz/OkX+o6/7Zg3VZxSAZeQzQpYomWmIpOehFM/rJNMSLVX5fgg6Q48ut2ETNKwdhm97mPNU643EBCoQ==",
-      "requires": {
-        "@popmotion/popcorn": "^0.4.4",
-        "framesync": "^4.0.0",
-        "hey-listen": "^1.0.8",
-        "style-value-types": "^3.1.7",
-        "tslib": "^1.10.0"
       }
     },
     "stylehacks": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dexie": "^3.0.1",
     "emotion-theming": "^10.0.27",
     "formik": "^2.1.4",
-    "framer-motion": "^2.0.0-beta.72",
+    "framer-motion": "^2.9.5",
     "iban": "0.0.14",
     "intl-dateformat": "^0.1.4",
     "ky": "^0.19.1",
@@ -87,18 +87,23 @@
   "jest": {
     "testEnvironment": "<rootDir>/lib/testing/customJsdomEnv.js",
     "automock": false,
+    "verbose": true,
     "preset": "ts-jest",
     "setupFilesAfterEnv": [
       "<rootDir>/setupTests.ts"
     ],
+    "transform": {
+      "^.+\\.ts$": "babel-jest",
+      "\\.svg$": "<rootDir>/lib/testing/fileTransformer.js"
+    },
     "moduleNameMapper": {
-      "\\.svg$": "<rootDir>/lib/testing/svgImportMock.js",
       "^~ui/(.*)$": "<rootDir>/ui/$1",
       "^~lib/(.*)$": "<rootDir>/lib/$1"
     },
     "globals": {
       "ts-jest": {
-        "tsConfig": "<rootDir>/tsconfig.jest.json"
+        "tsConfig": "<rootDir>/tsconfig.jest.json",
+        "babelConfig": "<rootDir>/babel.config.js"
       }
     }
   }

--- a/setupTests.ts
+++ b/setupTests.ts
@@ -8,6 +8,16 @@ import fetchMock from 'fetch-mock-jest'
 const noop = () => void 1
 Object.defineProperty(window, 'scrollTo', { value: noop, writable: true })
 
+declare global {
+  interface SVGElement {
+    getTotalLength(): number
+  }
+}
+
+if (!SVGElement.prototype.getTotalLength) {
+  SVGElement.prototype.getTotalLength = () => 1
+}
+
 beforeEach(() => {
   queryCache.clear()
   setConsole({ log: noop, warn: noop, error: noop })


### PR DESCRIPTION
Sadly this is not perfect, there is one warning left:

```
Warning: Invalid value for prop `css` on <svg> tag. Either remove it from the element, or pass a string or number value to keep it in the DOM. For details, see https://fb.me/react-attribute-behavior
```

My hope is that this will be gone after we update all dependencies in this repo. Especially `react` and `typescript`.

closes [#110](https://github.com/railslove/recover-backlog/issues/110)