### PR TITLE
i18n user language

### DIFF
--- a/lib/hooks/usePersistLocaleCookie.ts
+++ b/lib/hooks/usePersistLocaleCookie.ts
@@ -1,6 +1,9 @@
 import { useRouter } from 'next/router'
 import { useEffect } from 'react'
 
+/**
+ * See: https://github.com/vinissimus/next-translate#10-how-to-save-the-user-defined-language
+ */
 export default function usePersistLocaleCookie() {
   const { locale, defaultLocale } = useRouter()
 

--- a/lib/hooks/usePersistLocaleCookie.ts
+++ b/lib/hooks/usePersistLocaleCookie.ts
@@ -1,21 +1,12 @@
-import { useRouter } from 'next/router'
-import { useEffect } from 'react'
-
 /**
  * See: https://github.com/vinissimus/next-translate#10-how-to-save-the-user-defined-language
+ * NOTE: kept here in case we also wean to use local storage
  */
 export default function usePersistLocaleCookie() {
-  const { locale, defaultLocale } = useRouter()
-
-  useEffect(
-    function persistLocaleCookie() {
-      if (locale !== defaultLocale) {
-        const date = new Date()
-        const expireMs = 100 * 24 * 60 * 60 * 1000 // 100 days
-        date.setTime(date.getTime() + expireMs)
-        document.cookie = `NEXT_LOCALE=${locale};expires=${date.toUTCString()};path=/`
-      }
-    },
-    [locale, defaultLocale]
-  )
+  return function persistLocale(locale: string) {
+    const date = new Date()
+    const expireMs = 100 * 24 * 60 * 60 * 1000 // 100 days
+    date.setTime(date.getTime() + expireMs)
+    document.cookie = `NEXT_LOCALE=${locale};expires=${date.toUTCString()};path=/`
+  }
 }

--- a/lib/hooks/usePersistLocaleCookie.ts
+++ b/lib/hooks/usePersistLocaleCookie.ts
@@ -1,6 +1,5 @@
 /**
- * See: https://github.com/vinissimus/next-translate#10-how-to-save-the-user-defined-language
- * NOTE: kept here in case we also wean to use local storage
+ * See: https://nextjs.org/docs/advanced-features/i18n-routing#leveraging-the-next_locale-cookie
  */
 export default function usePersistLocaleCookie() {
   return function persistLocale(locale: string) {

--- a/lib/hooks/usePersistLocaleCookie.ts
+++ b/lib/hooks/usePersistLocaleCookie.ts
@@ -1,0 +1,18 @@
+import { useRouter } from 'next/router'
+import { useEffect } from 'react'
+
+export default function usePersistLocaleCookie() {
+  const { locale, defaultLocale } = useRouter()
+
+  useEffect(
+    function persistLocaleCookie() {
+      if (locale !== defaultLocale) {
+        const date = new Date()
+        const expireMs = 100 * 24 * 60 * 60 * 1000 // 100 days
+        date.setTime(date.getTime() + expireMs)
+        document.cookie = `NEXT_LOCALE=${locale};expires=${date.toUTCString()};path=/`
+      }
+    },
+    [locale, defaultLocale]
+  )
+}

--- a/locales/defaults.d.ts
+++ b/locales/defaults.d.ts
@@ -1,8 +1,0 @@
-import { SupportedLanguage } from '~locales/types'
-
-type LocalesConfigDefaults = {
-  locales: SupportedLanguage[]
-  defaultLocale: SupportedLanguage
-}
-
-export default LocalesConfigDefaults

--- a/locales/defaults.js
+++ b/locales/defaults.js
@@ -1,0 +1,8 @@
+/**
+ * this will be used in next.config.js and other places
+ * see: https://nextjs.org/docs/advanced-features/i18n-routing#locale-strategies
+ */
+exports = module.exports = {
+  locales: ['de', 'en', 'pl'],
+  defaultLocale: 'de',
+}

--- a/locales/defaults.js
+++ b/locales/defaults.js
@@ -3,6 +3,6 @@
  * see: https://nextjs.org/docs/advanced-features/i18n-routing#locale-strategies
  */
 exports = module.exports = {
-  locales: ['de', 'en', 'pl'],
+  locales: ['de', 'en'],
   defaultLocale: 'de',
 }

--- a/locales/defaults.json
+++ b/locales/defaults.json
@@ -1,4 +1,0 @@
-{
-  "locales": ["de", "en"],
-  "defaultLocale": "de"
-}

--- a/locales/defaults.json
+++ b/locales/defaults.json
@@ -1,4 +1,4 @@
 {
   "locales": ["de", "en"],
-  "defaultLocale": "en"
+  "defaultLocale": "de"
 }

--- a/locales/generate.js
+++ b/locales/generate.js
@@ -1,7 +1,4 @@
-const {
-  defaultLocale,
-  locales: supportedLanguages,
-} = require('./defaults.json')
+const { defaultLocale, locales: supportedLanguages } = require('./defaults')
 
 /**
  *

--- a/locales/loadPageLocale.ts
+++ b/locales/loadPageLocale.ts
@@ -7,7 +7,7 @@ import { LocaleContextProps } from '~locales/useLocaleContext'
 async function loadPageLocale(
   props: AppContext
 ): Promise<Partial<LocaleContextProps>> {
-  const locale = props.ctx.locale
+  const locale = props.router.locale
   const { pathname } = props.ctx
 
   if (config[pathname]) {

--- a/locales/useLocaleContext.ts
+++ b/locales/useLocaleContext.ts
@@ -1,6 +1,6 @@
 import { createContext, useContext } from 'react'
 
-import localesConfig from '~locales/defaults.json'
+import localesConfig from '~locales/defaults'
 import placeholderLocale from '~pages/index.de'
 import { PageLocaleResource, SupportedLanguage } from '~locales/types'
 

--- a/locales/useLocaleObject.ts
+++ b/locales/useLocaleObject.ts
@@ -28,12 +28,12 @@ const useLocaleObject = <K extends string, V extends unknown>(
 
   function t<K extends keyof L>(key: K, options: translateOptions = {}): L[K] {
     if (!options.useEnv) {
-      return currentLocale ? currentLocale[key] : (key as L[K])
+      return currentLocale ? currentLocale[key] : (`[${key}]` as L[K])
     }
 
     const envLocale = currentLocale[`${key}_${BUILD_VARIANT}`]
 
-    return envLocale || currentLocale[key] || (key as L[K])
+    return envLocale || currentLocale[key] || (`[${key}]` as L[K])
   }
 
   return { t, lang: language }

--- a/locales/usePageLocale.ts
+++ b/locales/usePageLocale.ts
@@ -12,7 +12,7 @@ const usePageLocale = <NS extends keyof PageLocalesResources>(_ns: NS) => {
   const localeValues = values as Result
 
   function translate<NSK extends keyof Result>(key: NSK): Result[NSK] {
-    return localeValues[key] || (`${key}` as unknown as Result[NSK])
+    return localeValues[key] || (`[${key}]` as unknown as Result[NSK])
   }
 
   return { t: translate, lang }

--- a/next.config.js
+++ b/next.config.js
@@ -1,18 +1,13 @@
 const execSync = require('child_process').execSync
 const { generateLocalesConfigAndTypes } = require('./locales/generate')
 
-const localesDefaults = require('./locales/defaults.json')
+const i18n = require('./locales/defaults')
 
 module.exports = {
   /**
    * i18n support
    */
-  i18n: {
-    ...localesDefaults,
-    defaultLocale:
-      process.env.NODE_ENV === 'test' ? 'de' : localesDefaults.defaultLocale,
-    localeDetection: false,
-  },
+  i18n,
   // needed to place locales under pages/ next to the page to be translated
   pageExtensions: ['tsx'],
 

--- a/next.config.js
+++ b/next.config.js
@@ -11,7 +11,7 @@ module.exports = {
     ...localesDefaults,
     defaultLocale:
       process.env.NODE_ENV === 'test' ? 'de' : localesDefaults.defaultLocale,
-    localeDetection: true,
+    localeDetection: false,
   },
   // needed to place locales under pages/ next to the page to be translated
   pageExtensions: ['tsx'],

--- a/package.json
+++ b/package.json
@@ -3,21 +3,19 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "predev": "npm run generated",
     "dev": "next dev",
-    "prebuild": "npm run generated",
     "build": "node ./scripts/build.js",
     "next-build": "next build",
     "start": "next start",
     "lint": "eslint . --ext .ts,.tsx,.js",
     "typecheck": "tsc --noemit",
-    "pretest": "npm run generated",
     "test": "cypress run",
     "cypress": "cypress",
     "start:ci": "NODE_ENV=test next dev -- -p 4040",
     "prepare": "husky install",
     "locales": "node scripts/locales.js",
     "generated": "npm run locales && npm run update-supported-browsers",
+    "postinstall": "npm run generated",
     "update-supported-browsers": "echo \"module.exports = $(browserslist-useragent-regexp --allowHigherVersions);\" > lib/supportedBrowsers.js"
   },
   "dependencies": {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -20,6 +20,7 @@ import {
 
 import SupportedBrowsersAlert from '~ui/SupportedBrowsersAlert/SupportedBrowsersAlert'
 import { theme, globalStyles } from '~ui/theme'
+import usePersistLocaleCookie from '~lib/hooks/usePersistLocaleCookie'
 
 const queryClient = new QueryClient()
 
@@ -40,6 +41,7 @@ const RecoverApp: RecoverAppFC = ({
   pageProps: { localeContext, ...pageProps },
 }) => {
   useA11yFocusRing()
+  usePersistLocaleCookie()
 
   return (
     <ThemeProvider theme={theme}>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -20,7 +20,6 @@ import {
 
 import SupportedBrowsersAlert from '~ui/SupportedBrowsersAlert/SupportedBrowsersAlert'
 import { theme, globalStyles } from '~ui/theme'
-import usePersistLocaleCookie from '~lib/hooks/usePersistLocaleCookie'
 
 const queryClient = new QueryClient()
 
@@ -41,7 +40,6 @@ const RecoverApp: RecoverAppFC = ({
   pageProps: { localeContext, ...pageProps },
 }) => {
   useA11yFocusRing()
-  usePersistLocaleCookie()
 
   return (
     <ThemeProvider theme={theme}>

--- a/ui/blocks/LanguageSwitcher.tsx
+++ b/ui/blocks/LanguageSwitcher.tsx
@@ -25,9 +25,6 @@ const LanguageSwitcher: React.FC = () => {
   const handleItemClick = useCallback(
     (ev: React.SyntheticEvent<HTMLAnchorElement>) => {
       const { locale } = ev.currentTarget.dataset
-
-      console.log('locale', locale)
-
       persistLocale(locale)
     },
     []

--- a/ui/blocks/LanguageSwitcher.tsx
+++ b/ui/blocks/LanguageSwitcher.tsx
@@ -5,11 +5,15 @@ import useLocaleContext from '~locales/useLocaleContext'
 import { RoundTriangle } from '~ui/anicons'
 import { Box, Text } from '~ui/core'
 import { zIndexLanguageSwitcher } from '~ui/zIndexConstants'
+import usePersistLocaleCookie from '~lib/hooks/usePersistLocaleCookie'
+
+const handlePreventDefault = (ev: React.SyntheticEvent) => ev.preventDefault()
 
 const LanguageSwitcher: React.FC = () => {
   const [isOpen, setIsOpen] = useState(false)
 
   const router = useRouter()
+  const persistLocale = usePersistLocaleCookie()
   const { lang: currentLocale, pageLocales = [] } = useLocaleContext()
 
   const availableLocales = pageLocales.filter((el) => el !== currentLocale)
@@ -17,6 +21,17 @@ const LanguageSwitcher: React.FC = () => {
   const handleToggle = useCallback(() => {
     setIsOpen(!isOpen)
   }, [isOpen])
+
+  const handleItemClick = useCallback(
+    (ev: React.SyntheticEvent<HTMLAnchorElement>) => {
+      const { locale } = ev.currentTarget.dataset
+
+      console.log('locale', locale)
+
+      persistLocale(locale)
+    },
+    []
+  )
 
   return (
     <>
@@ -55,6 +70,7 @@ const LanguageSwitcher: React.FC = () => {
           top="100%"
           left="-1px"
           right="-1px"
+          role="menu"
           backgroundColor="white"
           css={{
             borderBottomLeftRadius: '4px',
@@ -75,6 +91,11 @@ const LanguageSwitcher: React.FC = () => {
                     width: '100%',
                     borderTop: '1px solid rgba(0,0,0,0.15)',
                   }}
+                  role="menuitem"
+                  tabIndex={0}
+                  data-locale={el}
+                  onClick={handleItemClick}
+                  onKeyPress={handlePreventDefault}
                 >
                   <Text
                     variant="regular"


### PR DESCRIPTION
Closes #312 

See: https://nextjs.org/docs/advanced-features/i18n-routing#leveraging-the-next_locale-cookie
Code taken from: https://github.com/vinissimus/next-translate#10-how-to-save-the-user-defined-language