### PR TITLE
fix wrong locale order in checkin page

### DIFF
--- a/pages/checkin.de.ts
+++ b/pages/checkin.de.ts
@@ -15,7 +15,7 @@ const de = {
 
   dataProtection1: 'Datenschutz ist uns dabei sehr wichtig!',
   dataProtection2: 'Ihre Daten werden verschlüsselt und sicher gespeichert.',
-  dataProtection2_rcvr: ' speichert Deine Daten verschlüsselt und sicher.',
+  dataProtection2_rcvr: 'speichert Deine Daten verschlüsselt und sicher.',
 
   ownerIsBlockedMessage: [
     'Die Kontaktdatenerfassung mit recover ist für diesen Betrieb leider nicht mehr aktiv. Bitte',

--- a/pages/checkin.de.ts
+++ b/pages/checkin.de.ts
@@ -13,13 +13,10 @@ const de = {
   coronaRegulations:
     'Durch die aktuellen Corona-Verordnungen musst du Deine Kontaktdaten hinterlegen, wenn Du in einem Betrieb bist der zu Schutzmaßnahmen verpflichtet ist, wie z.B. Restaurants. Die App kann auch freiwillig genutzt werden, um die Nachverfolgung zu unterstützen.',
 
-  dataProtection: [
-    'Datenschutz ist uns dabei sehr wichtig!',
-    isRcvrEnv
-      ? 'speichert Deine Daten verschlüsselt und sicher.'
-      : 'Ihre Daten werden verschlüsselt und sicher gespeichert.',
-    'Ihre Daten werden verschlüsselt und sicher gespeichert.',
-  ].join(' '),
+  dataProtection1: 'Datenschutz ist uns dabei sehr wichtig!',
+  dataProtection2: isRcvrEnv
+    ? 'speichert Deine Daten verschlüsselt und sicher.'
+    : 'Ihre Daten werden verschlüsselt und sicher gespeichert.',
 
   ownerIsBlockedMessage: [
     'Die Kontaktdatenerfassung mit recover ist für diesen Betrieb leider nicht mehr aktiv. Bitte',

--- a/pages/checkin.de.ts
+++ b/pages/checkin.de.ts
@@ -14,9 +14,8 @@ const de = {
     'Durch die aktuellen Corona-Verordnungen musst du Deine Kontaktdaten hinterlegen, wenn Du in einem Betrieb bist der zu Schutzmaßnahmen verpflichtet ist, wie z.B. Restaurants. Die App kann auch freiwillig genutzt werden, um die Nachverfolgung zu unterstützen.',
 
   dataProtection1: 'Datenschutz ist uns dabei sehr wichtig!',
-  dataProtection2: isRcvrEnv
-    ? 'speichert Deine Daten verschlüsselt und sicher.'
-    : 'Ihre Daten werden verschlüsselt und sicher gespeichert.',
+  dataProtection2: 'Ihre Daten werden verschlüsselt und sicher gespeichert.',
+  dataProtection2_rcvr: ' speichert Deine Daten verschlüsselt und sicher.',
 
   ownerIsBlockedMessage: [
     'Die Kontaktdatenerfassung mit recover ist für diesen Betrieb leider nicht mehr aktiv. Bitte',

--- a/pages/checkin.en.ts
+++ b/pages/checkin.en.ts
@@ -12,13 +12,10 @@ const en: typeof de = {
   coronaRegulations:
     'Current corona regulations require you to leave your contact information if you are in a business that is required to take protective measures, such as restaurants. The app can also be used voluntarily to assist with tracking.',
 
-  dataProtection: [
-    'Privacy is very important to us in this!',
-    isRcvrEnv
-      ? 'stores your data encrypted and secure.'
-      : 'Your data is stored encrypted and secure.',
-    'Your data will be stored encrypted and secure.',
-  ].join(' '),
+  dataProtection1: 'Data protection is very important to us!',
+  dataProtection2: isRcvrEnv
+    ? 'stores your data encrypted and secure.'
+    : 'Your data will be stored encrypted and secure',
 
   ownerIsBlockedMessage: [
     'Sorry, contact data collection with recover is no longer active for this business. Please',

--- a/pages/checkin.en.ts
+++ b/pages/checkin.en.ts
@@ -14,7 +14,7 @@ const en: typeof de = {
 
   dataProtection1: 'Data protection is very important to us!',
   dataProtection2: 'stores your data encrypted and secure',
-  dataProtection2_rcvr: ' stores your data encrypted and secure.',
+  dataProtection2_rcvr: 'stores your data encrypted and secure.',
 
   ownerIsBlockedMessage: [
     'Sorry, contact data collection with recover is no longer active for this business. Please',

--- a/pages/checkin.en.ts
+++ b/pages/checkin.en.ts
@@ -13,7 +13,7 @@ const en: typeof de = {
     'Current corona regulations require you to leave your contact information if you are in a business that is required to take protective measures, such as restaurants. The app can also be used voluntarily to assist with tracking.',
 
   dataProtection1: 'Data protection is very important to us!',
-  dataProtection2: 'stores your data encrypted and secure',
+  dataProtection2: 'Your data is encrypted and stored securely.',
   dataProtection2_rcvr: 'stores your data encrypted and secure.',
 
   ownerIsBlockedMessage: [

--- a/pages/checkin.en.ts
+++ b/pages/checkin.en.ts
@@ -13,9 +13,8 @@ const en: typeof de = {
     'Current corona regulations require you to leave your contact information if you are in a business that is required to take protective measures, such as restaurants. The app can also be used voluntarily to assist with tracking.',
 
   dataProtection1: 'Data protection is very important to us!',
-  dataProtection2: isRcvrEnv
-    ? 'stores your data encrypted and secure.'
-    : 'Your data will be stored encrypted and secure',
+  dataProtection2: 'stores your data encrypted and secure',
+  dataProtection2_rcvr: ' stores your data encrypted and secure.',
 
   ownerIsBlockedMessage: [
     'Sorry, contact data collection with recover is no longer active for this business. Please',

--- a/pages/checkin.pl.ts
+++ b/pages/checkin.pl.ts
@@ -14,13 +14,10 @@ const pl: typeof de = {
   coronaRegulations:
     "Ze względu na obowiązujące przepisy corona, musisz zostawić swoje dane kontaktowe, jeśli jesteś w biznesie, który jest zobowiązany do podjęcia środków ochronnych, takich jak restauracje.' Aplikacja może być również używana dobrowolnie, aby pomóc w śledzeniu",
 
-  dataProtection: [
-    'Ochrona danych jest dla nas bardzo ważna!',
-    isRcvrEnv
-      ? 'przechowuje Twoje dane zaszyfrowane i bezpieczne'
-      : 'Twoje dane są przechowywane w sposób zaszyfrowany i bezpieczny.',
-    'Twoje dane będą przechowywane w sposób zaszyfrowany i bezpieczny',
-  ].join(' '),
+  dataProtection1: 'Ochrona danych jest dla nas bardzo ważna!',
+  dataProtection2: isRcvrEnv
+    ? 'przechowuje Twoje dane zaszyfrowane i bezpieczne'
+    : 'Twoje dane są przechowywane w sposób zaszyfrowany i bezpieczny',
 
   ownerIsBlockedMessage: [
     'Przepraszamy, zbieranie danych kontaktowych z odzysku nie jest już aktywne dla tej firmy. Proszę',

--- a/pages/checkin.pl.ts
+++ b/pages/checkin.pl.ts
@@ -15,7 +15,8 @@ const pl: typeof de = {
     "Ze względu na obowiązujące przepisy corona, musisz zostawić swoje dane kontaktowe, jeśli jesteś w biznesie, który jest zobowiązany do podjęcia środków ochronnych, takich jak restauracje.' Aplikacja może być również używana dobrowolnie, aby pomóc w śledzeniu",
 
   dataProtection1: 'Ochrona danych jest dla nas bardzo ważna!',
-  dataProtection2: 'przechowuje Twoje dane w sposób zaszyfrowany i bezpieczny',
+  dataProtection2:
+    'Twoje dane są zaszyfrowane i przechowywane w bezpieczny sposób.',
   dataProtection2_rcvr: 'przechowuje Twoje dane zaszyfrowane i bezpieczne',
 
   ownerIsBlockedMessage: [

--- a/pages/checkin.pl.ts
+++ b/pages/checkin.pl.ts
@@ -15,9 +15,8 @@ const pl: typeof de = {
     "Ze względu na obowiązujące przepisy corona, musisz zostawić swoje dane kontaktowe, jeśli jesteś w biznesie, który jest zobowiązany do podjęcia środków ochronnych, takich jak restauracje.' Aplikacja może być również używana dobrowolnie, aby pomóc w śledzeniu",
 
   dataProtection1: 'Ochrona danych jest dla nas bardzo ważna!',
-  dataProtection2: isRcvrEnv
-    ? 'przechowuje Twoje dane zaszyfrowane i bezpieczne'
-    : 'Twoje dane są przechowywane w sposób zaszyfrowany i bezpieczny',
+  dataProtection2: 'przechowuje Twoje dane w sposób zaszyfrowany i bezpieczny',
+  dataProtection2_rcvr: ' przechowuje Twoje dane zaszyfrowane i bezpieczne',
 
   ownerIsBlockedMessage: [
     'Przepraszamy, zbieranie danych kontaktowych z odzysku nie jest już aktywne dla tej firmy. Proszę',

--- a/pages/checkin.pl.ts
+++ b/pages/checkin.pl.ts
@@ -16,7 +16,7 @@ const pl: typeof de = {
 
   dataProtection1: 'Ochrona danych jest dla nas bardzo ważna!',
   dataProtection2: 'przechowuje Twoje dane w sposób zaszyfrowany i bezpieczny',
-  dataProtection2_rcvr: ' przechowuje Twoje dane zaszyfrowane i bezpieczne',
+  dataProtection2_rcvr: 'przechowuje Twoje dane zaszyfrowane i bezpieczne',
 
   ownerIsBlockedMessage: [
     'Przepraszamy, zbieranie danych kontaktowych z odzysku nie jest już aktywne dla tej firmy. Proszę',

--- a/pages/checkin.tsx
+++ b/pages/checkin.tsx
@@ -217,7 +217,8 @@ export default function CheckinPage() {
             <p>{t('address')}</p>
             <p>
               {t('dataProtection1')}
-              {isRcvrEnv ? <b>recover</b> : null} {t('dataProtection2')}
+              {isRcvrEnv ? <b>recover</b> : null}
+              {isRcvrEnv ? t('dataProtection2_rcvr') : t('dataProtection2')}
             </p>
           </Text>
           <Box height={6} />

--- a/pages/checkin.tsx
+++ b/pages/checkin.tsx
@@ -218,6 +218,7 @@ export default function CheckinPage() {
             <p>
               {t('dataProtection1')}
               {isRcvrEnv ? <b>recover</b> : null}
+              {isRcvrEnv ? ' ' : null}
               {isRcvrEnv ? t('dataProtection2_rcvr') : t('dataProtection2')}
             </p>
           </Text>

--- a/pages/checkin.tsx
+++ b/pages/checkin.tsx
@@ -216,9 +216,8 @@ export default function CheckinPage() {
             <p>{t('introText')}</p>
             <p>{t('address')}</p>
             <p>
-              {isRcvrEnv ? <b>recover</b> : null}
-              {isRcvrEnv ? ' ' : null}
-              {t('dataProtection')}
+              {t('dataProtection1')}
+              {isRcvrEnv ? <b>recover</b> : null} {t('dataProtection2')}
             </p>
           </Text>
           <Box height={6} />


### PR DESCRIPTION
Closes #341.

This was clearly due to trying to keep the boldface for `recover`.

Here commit before having locales:

- https://github.com/railslove/rcvr-app/blob/638a7c3258ac58dc7220bc7e49346bb052214382/pages/checkin.tsx#L205-L223